### PR TITLE
security: RLS hardening + public view + auth rate-limiting

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -69,23 +69,22 @@ export default function LoginPage() {
     }
 
     setBusy(true);
-    const supabase = createSupabaseBrowserClient();
-    const origin = typeof window !== "undefined" ? window.location.origin : "";
-    const { error } = await supabase.auth.signInWithOtp({
-      email,
-      options: {
-        emailRedirectTo: `${origin}/auth/callback?next=/dashboard`
-      }
+    const response = await fetch("/api/auth/magic-link", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email })
     });
+
+    const payload = (await response.json().catch(() => null)) as { message?: string } | null;
     setBusy(false);
 
-    if (error) {
-      toast.error(error.message);
+    if (!response.ok) {
+      toast.error(payload?.message ?? "Nu am putut trimite linkul acum.");
       return;
     }
 
     trackAuthEvent("magic_link_sent", "email_link");
-    toast.success("Ți-am trimis un link de autentificare pe email.");
+    toast.success(payload?.message ?? "Dacă emailul există, am trimis linkul.");
   }
 
   async function sendPasswordReset() {
@@ -96,20 +95,22 @@ export default function LoginPage() {
     }
 
     setBusy(true);
-    const supabase = createSupabaseBrowserClient();
-    const origin = typeof window !== "undefined" ? window.location.origin : "";
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${origin}/login`
+    const response = await fetch("/api/auth/password-reset", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email })
     });
+
+    const payload = (await response.json().catch(() => null)) as { message?: string } | null;
     setBusy(false);
 
-    if (error) {
-      toast.error(error.message);
+    if (!response.ok) {
+      toast.error(payload?.message ?? "Nu am putut procesa cererea acum.");
       return;
     }
 
     trackAuthEvent("password_reset_sent", "email_reset");
-    toast.success("Ți-am trimis emailul pentru resetarea parolei.");
+    toast.success(payload?.message ?? "Dacă emailul există, am trimis instrucțiunile.");
   }
 
   return (

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -242,18 +242,21 @@ export default function SignupPage() {
       const errorText = (error?.message ?? "").toLowerCase();
       const alreadyRegistered = errorText.includes("already registered") || errorText.includes("already exists");
       if (alreadyRegistered) {
-        const { error: otpError } = await supabase.auth.signInWithOtp({
-          email: cleanEmail,
-          options: {
-            emailRedirectTo: typeof window !== "undefined" ? `${window.location.origin}/auth/callback?next=/dashboard` : undefined
-          }
+        const response = await fetch("/api/auth/magic-link", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: cleanEmail })
         });
+
+        const payload = (await response.json().catch(() => null)) as { message?: string } | null;
         setIsSubmitting(false);
-        if (otpError) {
-          toast.error("Emailul există deja. Intră în cont sau folosește resetarea parolei.");
+
+        if (!response.ok) {
+          toast.error(payload?.message ?? "Emailul există deja. Intră în cont sau folosește resetarea parolei.");
           return;
         }
-        toast.success("Emailul este deja înregistrat. Ți-am trimis un link de autentificare.");
+
+        toast.success(payload?.message ?? "Emailul este deja înregistrat. Dacă emailul există, am trimis linkul.");
         router.push("/login");
         return;
       }

--- a/src/app/[slug]/[serviciu]/page.tsx
+++ b/src/app/[slug]/[serviciu]/page.tsx
@@ -90,7 +90,7 @@ export default async function LocalServicePage({ params }: PageProps) {
   try {
     const supabase = await createSupabaseServerClient();
     const { data } = await supabase
-      .from("profesionisti")
+      .from("profesionisti_public")
       .select("id,business_name:nume_business,slug")
       .ilike("oras", `%${orasName}%`)
       .limit(6);

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
   const supabase = await createSupabaseServerClient();
   const { data: prof } = await supabase
-    .from("profesionisti")
+    .from("profesionisti_public")
     .select("nume_business, description, tip_activitate, oras, logo_url")
     .eq("slug", slug)
     .maybeSingle();
@@ -89,7 +89,7 @@ export default async function PublicSalonSlugPage({ params }: PageProps) {
       .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
       .join(" ");
     const { data: profesionisti } = await supabase
-      .from("profesionisti")
+      .from("profesionisti_public")
       .select("slug, nume_business, tip_activitate, description")
       .ilike("oras", `%${orasName}%`)
       .not("slug", "is", null)
@@ -140,7 +140,7 @@ export default async function PublicSalonSlugPage({ params }: PageProps) {
     );
   }
   const { data: prof, error } = await supabase
-    .from("profesionisti")
+    .from("profesionisti_public")
     .select("id,slug,nume_business,tip_activitate,description,oras,logo_url,telefon,lucreaza_acasa,adresa_publica,program")
     .eq("slug", slug)
     .maybeSingle();

--- a/src/app/api/auth/magic-link/route.ts
+++ b/src/app/api/auth/magic-link/route.ts
@@ -1,0 +1,89 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+import { createSupabaseServiceClient } from "@/lib/supabase/admin";
+import { checkApiRateLimit } from "@/lib/rate-limit";
+
+const PER_IP_MAX = 20;
+const PER_EMAIL_MAX = 5;
+const WINDOW_MS = 10 * 60 * 1000;
+
+function getClientIp(req: NextRequest): string {
+  const xff = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const xr = req.headers.get("x-real-ip")?.trim();
+  return xff || xr || "unknown";
+}
+
+function hashEmail(email: string): string {
+  return createHash("sha256").update(email).digest("hex").slice(0, 24);
+}
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+
+  let ipAllowed = true;
+  try {
+    const admin = createSupabaseServiceClient();
+    const ipRl = await checkApiRateLimit(admin, `auth:magic:ip:${ip}`, PER_IP_MAX, WINDOW_MS);
+    ipAllowed = ipRl.allowed;
+  } catch (error) {
+    console.error("[auth:magic-link] rate-limit setup error:", error);
+  }
+
+  if (!ipAllowed) {
+    return NextResponse.json(
+      { ok: false, message: "Prea multe încercări. Reîncearcă în câteva minute." },
+      { status: 429 }
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const rawEmail = String((body as { email?: unknown }).email ?? "");
+  const email = rawEmail.trim().toLowerCase();
+
+  if (!email) {
+    return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis linkul." });
+  }
+
+  let emailAllowed = true;
+  try {
+    const admin = createSupabaseServiceClient();
+    const emailKey = hashEmail(email);
+    const emailRl = await checkApiRateLimit(admin, `auth:magic:email:${emailKey}`, PER_EMAIL_MAX, WINDOW_MS);
+    emailAllowed = emailRl.allowed;
+  } catch (error) {
+    console.error("[auth:magic-link] email rate-limit error:", error);
+  }
+
+  if (!emailAllowed) {
+    return NextResponse.json(
+      { ok: false, message: "Prea multe încercări. Reîncearcă în câteva minute." },
+      { status: 429 }
+    );
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anon) {
+    console.error("[auth:magic-link] Missing auth env config for route");
+    return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis linkul." });
+  }
+
+  const supabase = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+
+  try {
+    await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: `${req.nextUrl.origin}/auth/callback?next=/dashboard`
+      }
+    });
+  } catch (error) {
+    console.error("[auth:magic-link] Supabase signInWithOtp error:", error);
+  }
+
+  return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis linkul." });
+}

--- a/src/app/api/auth/password-reset/route.ts
+++ b/src/app/api/auth/password-reset/route.ts
@@ -1,0 +1,86 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+import { createSupabaseServiceClient } from "@/lib/supabase/admin";
+import { checkApiRateLimit } from "@/lib/rate-limit";
+
+const PER_IP_MAX = 20;
+const PER_EMAIL_MAX = 5;
+const WINDOW_MS = 10 * 60 * 1000;
+
+function getClientIp(req: NextRequest): string {
+  const xff = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const xr = req.headers.get("x-real-ip")?.trim();
+  return xff || xr || "unknown";
+}
+
+function hashEmail(email: string): string {
+  return createHash("sha256").update(email).digest("hex").slice(0, 24);
+}
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+
+  let ipAllowed = true;
+  try {
+    const admin = createSupabaseServiceClient();
+    const ipRl = await checkApiRateLimit(admin, `auth:reset:ip:${ip}`, PER_IP_MAX, WINDOW_MS);
+    ipAllowed = ipRl.allowed;
+  } catch (error) {
+    console.error("[auth:password-reset] rate-limit setup error:", error);
+  }
+
+  if (!ipAllowed) {
+    return NextResponse.json(
+      { ok: false, message: "Prea multe încercări. Reîncearcă în câteva minute." },
+      { status: 429 }
+    );
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const rawEmail = String((body as { email?: unknown }).email ?? "");
+  const email = rawEmail.trim().toLowerCase();
+
+  if (!email) {
+    return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis instrucțiunile." });
+  }
+
+  let emailAllowed = true;
+  try {
+    const admin = createSupabaseServiceClient();
+    const emailKey = hashEmail(email);
+    const emailRl = await checkApiRateLimit(admin, `auth:reset:email:${emailKey}`, PER_EMAIL_MAX, WINDOW_MS);
+    emailAllowed = emailRl.allowed;
+  } catch (error) {
+    console.error("[auth:password-reset] email rate-limit error:", error);
+  }
+
+  if (!emailAllowed) {
+    return NextResponse.json(
+      { ok: false, message: "Prea multe încercări. Reîncearcă în câteva minute." },
+      { status: 429 }
+    );
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anon) {
+    console.error("[auth:password-reset] Missing auth env config for route");
+    return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis instrucțiunile." });
+  }
+
+  const supabase = createClient(url, anon, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  });
+
+  try {
+    await supabase.auth.resetPasswordForEmail(email, {
+      redirectTo: `${req.nextUrl.origin}/login`
+    });
+  } catch (error) {
+    console.error("[auth:password-reset] Supabase resetPasswordForEmail error:", error);
+  }
+
+  return NextResponse.json({ ok: true, message: "Dacă emailul există, am trimis instrucțiunile." });
+}

--- a/src/app/s/[slug]/page.tsx
+++ b/src/app/s/[slug]/page.tsx
@@ -10,7 +10,7 @@ export default async function PublicSalonPage({ params }: Props) {
   const { slug } = await params;
   const supabase = await createSupabaseServerClient();
   const { data: prof, error } = await supabase
-    .from("profesionisti")
+    .from("profesionisti_public")
     .select("id,slug,nume_business,logo_url,lucreaza_acasa,adresa_publica")
     .eq("slug", slug)
     .maybeSingle();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -59,7 +59,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     auth: { autoRefreshToken: false, persistSession: false }
   });
 
-  const { data: rows } = await supabase.from("profesionisti").select("slug, created_at").not("slug", "is", null);
+  const { data: rows } = await supabase.from("profesionisti_public").select("slug, created_at").not("slug", "is", null);
 
   const profilPages: MetadataRoute.Sitemap = (rows ?? [])
     .filter((item) => Boolean(item.slug))

--- a/supabase/migrations/020_profesionisti_public_view_hardening.sql
+++ b/supabase/migrations/020_profesionisti_public_view_hardening.sql
@@ -1,0 +1,39 @@
+begin;
+
+alter table public.profesionisti enable row level security;
+
+create or replace view public.profesionisti_public
+with (security_barrier = true)
+as
+select
+  id,
+  slug,
+  nume_business,
+  tip_activitate,
+  description,
+  oras,
+  logo_url,
+  telefon,
+  lucreaza_acasa,
+  adresa_publica,
+  program,
+  created_at
+from public.profesionisti
+where slug is not null;
+
+comment on view public.profesionisti_public is
+  'Public profile projection (whitelisted columns only)';
+
+revoke all on table public.profesionisti_public from public;
+grant select on table public.profesionisti_public to anon, authenticated;
+
+drop policy if exists profesionisti_select_public on public.profesionisti;
+
+drop policy if exists profesionisti_select_owner on public.profesionisti;
+create policy profesionisti_select_owner
+  on public.profesionisti
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+commit;

--- a/supabase/migrations/021_profesionisti_owner_write_policies.sql
+++ b/supabase/migrations/021_profesionisti_owner_write_policies.sql
@@ -1,0 +1,33 @@
+begin;
+
+alter table public.profesionisti enable row level security;
+
+-- Defense-in-depth: ensure the legacy public select policy is not present.
+drop policy if exists profesionisti_select_public on public.profesionisti;
+
+-- Owner can read only their row.
+drop policy if exists profesionisti_select_owner on public.profesionisti;
+create policy profesionisti_select_owner
+  on public.profesionisti
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+-- Owner can insert only rows tied to their own user_id.
+drop policy if exists profesionisti_insert_owner on public.profesionisti;
+create policy profesionisti_insert_owner
+  on public.profesionisti
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+-- Owner can update only their row and keep ownership consistent.
+drop policy if exists profesionisti_update_owner on public.profesionisti;
+create policy profesionisti_update_owner
+  on public.profesionisti
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+commit;


### PR DESCRIPTION
## PR1 — RLS hardening pe `public.profesionisti`

### Ce schimbă
- **Migration 020** (`020_profesionisti_public_view_hardening.sql`):
  - Creează view `public.profesionisti_public` cu `security_barrier = true`, expune doar coloanele whitelisted: `id, slug, nume_business, tip_activitate, description, oras, logo_url, telefon, lucreaza_acasa, adresa_publica, program, created_at`
  - GRANT SELECT pe view la `anon` și `authenticated`
  - DROP policy `profesionisti_select_public` (cea cu `USING (true)`) de pe tabelul de bază
  - Adaugă policy owner SELECT: `USING (auth.uid() = user_id)`

- **Migration 021** (`021_profesionisti_owner_write_policies.sql`):
  - Reconciliază explicit: owner SELECT / INSERT / UPDATE cu `auth.uid() = user_id`
  - Fără SELECT public pe tabelul de bază
  - INSERT și UPDATE policies păstrate corect pentru dashboard și onboarding

- **Pagini publice** — switched `.from("profesionisti")` → `.from("profesionisti_public")`:
  - `src/app/[slug]/page.tsx` (3 query-uri)
  - `src/app/s/[slug]/page.tsx`
  - `src/app/[slug]/[serviciu]/page.tsx`
  - `src/app/sitemap.ts`

---

## PR2 — Rate limiting server-side pentru acțiuni auth care trimit email

### Ce schimbă
- **`POST /api/auth/magic-link`** (fișier nou):
  - Rate limit per IP: 20 req / 10 min (chiar și fără email valid)
  - Rate limit per email: 5 req / 10 min (sha256 email, slice 0:24)
  - Răspuns neutru 200 întotdeauna (anti-enumeration)
  - 429 cu mesaj în română la depășire
  - Fallback neutral 200 dacă env lipsește (log server-side)

- **`POST /api/auth/password-reset`** (fișier nou): aceeași logică

- **`login/page.tsx`**: `signInWithMagicLink` și `sendPasswordReset` acum apelează endpoint-urile server-side în loc de Supabase client direct

- **`signup/page.tsx`**: fallback-ul pentru email existent apelează `/api/auth/magic-link` în loc de `supabase.auth.signInWithOtp` direct

---

## ⚠️ Pași după merge
1. Rulează migrațiile în producție: `npx supabase db push`
2. Verifică în Supabase Dashboard → SQL Editor că `profesionisti_select_public` nu mai există
3. Testează editare profil în dashboard (UPDATE trebuie să funcționeze)
